### PR TITLE
Java Standard第１７回演習課題「受講生情報削除処理の実装」の提出（２０２５年５月１３日）

### DIFF
--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -93,4 +93,12 @@ public class StudentController {
     // 更新後に受講生一覧ページへ
     return "redirect:/studentList";
   }
+
+  /* 論理削除した受講生情報を復元する
+  @PostMapping("/restoreStudent/{id}")
+  public String restoreStudent(@PathVariable Long id) {
+    service.restoreStudent(id);
+    return "redirect:/studentList";
+  }*/
+
 }

--- a/src/main/java/raisetech/StudentManagement/repositry/StudentRepository.java
+++ b/src/main/java/raisetech/StudentManagement/repositry/StudentRepository.java
@@ -12,11 +12,11 @@ import raisetech.StudentManagement.data.StudentsCourses;
 @Mapper
 public interface StudentRepository {
 
-  //WHERE文でisDeleted=trueの項目を除外する➡isDeleted=falseにして一覧画面に出ないようにする
-  @Select("SELECT * FROM students WHERE isDeleted = false")
+  // 受講生情報を検索する(論理削除のレコードを一覧画面に表示させない)
+  @Select("SELECT * FROM students")
   List<Student> search();
 
-  // 単一の受講生情報を検索する
+  // idに基づいた単一の受講生情報を検索する
   @Select("SELECT * FROM students WHERE id = #{id}")
   Student searchStudent(String id);
 
@@ -49,4 +49,8 @@ public interface StudentRepository {
   // 受講生コース情報の更新処理
   @Update("UPDATE students_courses SET course_name = #{courseName} WHERE id = #{id}")
   void updateStudentsCourses(StudentsCourses studentsCourses);
+
+  /*論理削除でキャンセルした受講生情報を復元する
+  @Update("UPDATE students SET isDeleted = false WHERE id = #{id}")
+  void restoreStudent(Long id);*/
 }

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -59,4 +59,11 @@ public class StudentService {
       repository.updateStudentsCourses(studentsCourse);
     }
   }
- }
+
+  /* 論理削除した受講生情報を復元する
+  @Transactional
+  public void restoreStudent(Long id) {
+    repository.restoreStudent(id);
+  }*/
+
+}

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -18,6 +18,7 @@
     <th>年齢</th>
     <th>性別</th>
     <th>備考</th>
+    <th>キャンセル</th>
   </tr>
   </thead>
   <tbody>
@@ -34,6 +35,9 @@
     <td th:text="${studentDetail.student.age}">20</td>
     <td th:text="${studentDetail.student.sex}">男性</td>
     <td th:text="${studentDetail.student.remark}">特になし</td>
+    <td>
+      <input type="checkbox" th:checked="${studentDetail.student.isDeleted}">
+    </td>
   </tr>
   </tbody>
 </table>

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -43,10 +43,14 @@
     <label for="remark">備考</label>
     <input type="text" id="remark" th:field="*{student.remark}" >
   </div>
+  <div>
+    <label for="isDeleted">キャンセル</label>
+    <input type="checkbox" id="isDeleted" th:field="*{student.isDeleted}" >
+  </div>
   <div th:each="course, stat : *{studentsCourses}">
-    <label for="id"
+    <label for="studentCourseId"
            th:for="studentCourse.__${stat.index}__.id">受講コースID：</label>
-    <input type="text" id="id" th:id="studentCourse.__${stat.index}__.id"
+    <input type="text" id="studentCourseId" th:id="studentCourse.__${stat.index}__.id"
            th:field="*{studentsCourses[__${stat.index}__].id}" />
     <label for="courseName"
            th:for="studentCourse.__${stat.index}__.courseName">受講コース名： </label>


### PR DESCRIPTION
Java Standard第１７回演習課題「受講生情報削除処理の実装」を提出します。
論理削除した後のレコードを復元する処理も実装してみました。
確認よろしくお願いいたします。