### PR TITLE
Java スタンダード第１７回演習課題「受講生情報削除処理の実装」の提出（２０２５年５月１３日）

### DIFF
--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -94,11 +94,11 @@ public class StudentController {
     return "redirect:/studentList";
   }
 
-  /* 論理削除した受講生情報を復元する
+  // 論理削除した受講生情報を復元する
   @PostMapping("/restoreStudent/{id}")
   public String restoreStudent(@PathVariable Long id) {
     service.restoreStudent(id);
     return "redirect:/studentList";
-  }*/
+  }
 
 }

--- a/src/main/java/raisetech/StudentManagement/repositry/StudentRepository.java
+++ b/src/main/java/raisetech/StudentManagement/repositry/StudentRepository.java
@@ -13,7 +13,7 @@ import raisetech.StudentManagement.data.StudentsCourses;
 public interface StudentRepository {
 
   // 受講生情報を検索する(論理削除のレコードを一覧画面に表示させない)
-  @Select("SELECT * FROM students")
+  @Select("SELECT * FROM students WHERE isDeleted = false")
   List<Student> search();
 
   // idに基づいた単一の受講生情報を検索する
@@ -50,7 +50,7 @@ public interface StudentRepository {
   @Update("UPDATE students_courses SET course_name = #{courseName} WHERE id = #{id}")
   void updateStudentsCourses(StudentsCourses studentsCourses);
 
-  /*論理削除でキャンセルした受講生情報を復元する
+  // 論理削除でキャンセルした受講生情報を復元する
   @Update("UPDATE students SET isDeleted = false WHERE id = #{id}")
-  void restoreStudent(Long id);*/
+  void restoreStudent(Long id);
 }

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -60,10 +60,10 @@ public class StudentService {
     }
   }
 
-  /* 論理削除した受講生情報を復元する
+  // 論理削除した受講生情報を復元する
   @Transactional
   public void restoreStudent(Long id) {
     repository.restoreStudent(id);
-  }*/
+  }
 
 }

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -18,7 +18,7 @@
     <th>年齢</th>
     <th>性別</th>
     <th>備考</th>
-    <th>キャンセル</th>
+    <th>キャンセル(削除)</th>
   </tr>
   </thead>
   <tbody>

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -44,7 +44,7 @@
     <input type="text" id="remark" th:field="*{student.remark}" >
   </div>
   <div>
-    <label for="isDeleted">キャンセル</label>
+    <label for="isDeleted">キャンセル(削除)</label>
     <input type="checkbox" id="isDeleted" th:field="*{student.isDeleted}" >
   </div>
   <div th:each="course, stat : *{studentsCourses}">


### PR DESCRIPTION
Java スタンダード第１７回演習課題「受講生情報削除処理の実装」を提出します。
論理削除した後の復元するコードも記述しました。
確認よろしくお願いいたします。