### PR TITLE
Java_Standard42 ドキュメントの必要性と作り方（２０２５年６月２０日）

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,15 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	// Thymeleaf
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+	// Validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// OpenAPI Generator
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
+
 	// 便利機能、ユーテイリティ
 	implementation 'org.apache.commons:commons-lang3:3.17.0'
+
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/raisetech/StudentManagement/StudentManagementApplication.java
+++ b/src/main/java/raisetech/StudentManagement/StudentManagementApplication.java
@@ -1,8 +1,11 @@
 package raisetech.StudentManagement;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+@OpenAPIDefinition(info = @Info(title = "受講生管理システム"))
 @SpringBootApplication
 
 public class StudentManagementApplication {

--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -1,5 +1,6 @@
 package raisetech.StudentManagement.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -22,7 +23,7 @@ import raisetech.StudentManagement.exception.TestException;
 import raisetech.StudentManagement.service.StudentService;
 
 /**
- *  受講生の検索、登録や更新などを行なうRSET APIとして受け付けるControllerです。(責務)
+ *  受講生の検索、登録や更新などを行なうRSET APIとして受け付けるControllerです。(Javadocコメント)
  */
 @Validated
 @RestController
@@ -41,6 +42,7 @@ public class StudentController {
    *
    * @return　受講生詳細一覧(全件)
    */
+  @Operation(summary = "一覧検索", description = "受講生の一覧を検索します。") // summary:一覧 descrption:詳細
   @GetMapping("/studentList")
   public List<StudentDetail> getStudentList() throws TestException{
     throw new TestException("現在このAPIは利用できません。URLは「studentList」ではなく「students」を利用してください。");
@@ -53,12 +55,14 @@ public class StudentController {
    * @param id 受講生ID
    * @return　単一の受講生
    */
+  @Operation(summary = "詳細検索", description = "IDに紐づく任意の受講生情報を取得します。")
   @GetMapping("/student/{id}")
   public StudentDetail getStudent(
       @PathVariable @Pattern(regexp = "^\\d+$") String id) {
     return service.searchStudent(id);
   }
 
+  @Operation(summary = "受講生コース一覧", description = "受講生のコース情報一覧を取得します。")
   @GetMapping("/studentsCourseList")
   public List<StudentCourse> getStudentsCoursesList() {
     return service.searchStudentCourseList();
@@ -70,6 +74,7 @@ public class StudentController {
    * @param studentDetail 受講生詳細
    * @return 実行結果
    */
+  @Operation(summary = "受講生登録", description = "受講生の情報を登録します。")
   @PostMapping("/registerStudent")
   public ResponseEntity<StudentDetail> registerStudent(@RequestBody @Valid StudentDetail studentDetail) {
     StudentDetail responseStudentDetail = service.registerStudent(studentDetail);
@@ -82,6 +87,7 @@ public class StudentController {
    * @param studentDetail 受講生詳細
    * @return 実行結果
    */
+  @Operation(summary = "受講生更新" ,description = "受講生の情報を更新します。")
   @PutMapping("/updateStudent") /** @PostMappingをPutMappingに機能変更 */
   public ResponseEntity<String> updateStudent(@RequestBody @Valid StudentDetail studentDetail) {
     service.updateStudent(studentDetail);
@@ -94,10 +100,10 @@ public class StudentController {
    * @param id 受講生ID
    * @return 受講生一覧(全件)
    */
+  @Operation(summary = "受講生復元", description = "論理削除された受講生情報を復元します。")
   @PostMapping("/restoreStudent/{id}")
   public String restoreStudent(@PathVariable Long id) {
     service.restoreStudent(id);
     return "redirect:/studentList";
   }
-
 }

--- a/src/main/java/raisetech/StudentManagement/data/Student.java
+++ b/src/main/java/raisetech/StudentManagement/data/Student.java
@@ -1,35 +1,43 @@
 package raisetech.StudentManagement.data;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.Setter;
 
 /**
  * 受講生を扱うオブジェクト。
  */
+@Schema(description = "受講生")
 @Getter
 @Setter
 public class Student {
 
+  @NotBlank
+  @Pattern(regexp = "^\\d+$")
   private Long id;
 
-  @NotBlank(message = "名前は必須です。")
+  @NotBlank
   private String name;
 
-  @NotBlank(message = "カナ名は必須です。")
+  @NotBlank
   private String kanaName;
   private String nickName;
 
-  @Email(message = "正しいメールアドレスを入力してください。")
+  @Email
   private String email;
 
-  @NotBlank(message = "地域名は必須です。")
+  @NotBlank
   private String area;
   private int age;
+
+  @NotBlank
   private String sex;
+
   private String remark;
   private Boolean isDeleted;
 }

--- a/src/main/java/raisetech/StudentManagement/data/StudentCourse.java
+++ b/src/main/java/raisetech/StudentManagement/data/StudentCourse.java
@@ -1,5 +1,6 @@
 package raisetech.StudentManagement.data;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
@@ -9,6 +10,7 @@ import lombok.Setter;
 /**
  * 受講生コース情報を扱うオブジェクト。
  */
+@Schema(description = "受講生コース情報")
 @Getter
 @Setter
 public class StudentCourse {
@@ -16,7 +18,7 @@ public class StudentCourse {
   private String id;
   private Long studentId;
 
-  @NotBlank(message = "コース名は必須です。")
+  @NotBlank
   private String courseName;
 
   @NotNull

--- a/src/main/java/raisetech/StudentManagement/domain/StudentDetail.java
+++ b/src/main/java/raisetech/StudentManagement/domain/StudentDetail.java
@@ -1,5 +1,6 @@
 package raisetech.StudentManagement.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -9,6 +10,7 @@ import lombok.Setter;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
 
+@Schema(description = "受講生詳細")
 @Getter
 @Setter
 @NoArgsConstructor /** 引数を全く用いないコンストラクタ */


### PR DESCRIPTION
Javaスタンダード第25回演習課題のドキュメントを作成しました。
①build.gradleにOpenAPI Generator implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'を設定
②StudentManagementApplicationに@OpenAPIDefinition(info = @Info(title = "受講生管理システム"))を設定
③Student.javaに@Schema(description = "受講生")を設定
④StudentCourse.javaに@Schema(description = "受講生コース情報")を設定
⑤StudentDetail.javaに@Schema(description = "受講生詳細")を設定
⑥StudentController.javaの各メソッドに@Operationを設定
