### PR TITLE
Java_Standard45_47 JUnitとAssertionとMockito_Serviceのテスト（２０２５年６月３０日）

### DIFF
--- a/src/test/java/raisetech/StudentManagement/service/StudentServiceTest.java
+++ b/src/test/java/raisetech/StudentManagement/service/StudentServiceTest.java
@@ -1,0 +1,138 @@
+package raisetech.StudentManagement.service;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import raisetech.StudentManagement.controller.converter.StudentConverter;
+import raisetech.StudentManagement.data.Student;
+import raisetech.StudentManagement.data.StudentCourse;
+import raisetech.StudentManagement.domain.StudentDetail;
+import raisetech.StudentManagement.repository.StudentRepository;
+
+@ExtendWith(MockitoExtension.class)
+class StudentServiceTest {
+
+  @Mock
+  private StudentRepository repository;
+
+  @Mock
+  private StudentConverter converter;
+
+  private StudentService sut;
+
+  @BeforeEach // methodごと
+  void before() {
+    sut = new StudentService(repository, converter);  // sut:serviceのテスト対象
+  }
+
+  @Test
+  void 受講生詳細一覧検索_リポジトリとコンバーターの処理が適切に呼び出せていること() {
+    // 事前準備(before) Serviceのエラー対策：Mock化（Mockito）
+    /* StudentService sut = new StudentService(repository, converter);
+    // List<StudentDetail> expected = new ArrayList<>(); // expected:テスト結果の予想 */
+    List<Student> studentList = new ArrayList<>();
+    List<StudentCourse> studentCourseList = new ArrayList<>();
+
+    Mockito.when(repository.search()).thenReturn(studentList);
+    Mockito.when(repository.searchStudentCourseList()).thenReturn(studentCourseList);
+
+    // 実行
+    /* List<StudentDetail> actual = */ sut.searchStudentList(); // actual:テスト検証対象
+
+    // 検証
+    // Assertions.assertEquals(expected, actual); //expected = actual
+    verify(repository, times(1)).search();
+    verify(repository, times(1)).searchStudentCourseList();
+    verify(converter, times(1)).convertStudentDetails(studentList, studentCourseList);
+
+    //　後処理
+  }
+
+  @Test
+  void 受講生詳細検索_IDに紐づきリポジトリの処理が適切に呼び出せていること() {
+    // 事前準備(before)
+    String id = "123";
+    Student student = new Student();
+    student.setId(123L);
+    List<StudentCourse> courseList = new ArrayList<>();
+
+    Mockito.when(repository.searchStudent(id)).thenReturn(student);
+    Mockito.when(repository.searchStudentCourse(student.getId())).thenReturn(courseList);
+
+    // 実行
+    StudentDetail result = sut.searchStudent(id);
+    // 検証
+    Assertions.assertEquals(courseList, result.getStudentCourseList());
+    Assertions.assertEquals(student, result.getStudent());
+  }
+
+  @Test
+  void 受講生コース一覧検索_リポジトリの処理が適切に呼び出せていること() {
+    // 事前準備(before)
+    List<StudentCourse> expectedList = new ArrayList<>();
+    Mockito.when(repository.searchStudentCourseList()).thenReturn(expectedList);
+
+    // 実行
+    List<StudentCourse> actual = sut.searchStudentCourseList();
+
+    // 検証
+    verify(repository, times(1)).searchStudentCourseList();
+    Assertions.assertEquals(expectedList, actual);
+  }
+
+  @Test
+  void 受講生登録処理_リポジトリの処理が適切に呼び出せていること() {
+    // 事前準備(before)
+    Student student = new Student();
+    student.setId(1L);
+
+    StudentCourse course = new StudentCourse();
+    List<StudentCourse> courseList = List.of(course);
+    StudentDetail studentDetail = new StudentDetail(student, courseList);
+
+    // 実行
+    StudentDetail result = sut.registerStudent(studentDetail);
+
+    // 検証
+    Mockito.verify(repository, times(1)).registerStudent(student);
+    Mockito.verify(repository, times(1)).registerStudentCourse(course);
+    Assertions.assertEquals(studentDetail, result);
+  }
+
+  @Test
+  void 受講生更新処理_リポジトリの更新メソッドが適切に呼び出せていること() {
+    // 事前準備(before)
+    Student student = new Student();
+    StudentCourse course = new StudentCourse();
+    List<StudentCourse> courseList = List.of(course);
+    StudentDetail studentDetail = new StudentDetail(student, courseList);
+
+    // 実行
+    sut.updateStudent(studentDetail);
+
+    // 検証
+    Mockito.verify(repository, times(1)).updateStudent(student);
+    Mockito.verify(repository, times(1)).updateStudentCourse(course);
+  }
+
+  @Test
+  void 受講生復元処理_リポジトリの処理が適切に呼び出せていること() {
+    // 事前準備(before)
+    Long studentId = 99L;
+
+    // 実行
+    sut.restoreStudent(studentId);
+
+    // 検証
+    Mockito.verify(repository, times(1)).restoreStudent(studentId);
+  }
+}


### PR DESCRIPTION
Javaスタンダード第27回演習課題のコードを実装しました。
①searchStudentが受講生詳細検索_IDに紐づきリポジトリの処理が適切に呼び出せていること()に該当します。
②registerStudentが受講生登録処理_リポジトリの処理が適切に呼び出せていること()に該当します。
③updateStudentが受講生更新処理_リポジトリの更新メソッドが適切に呼び出せていること()に該当します。
受講生コース一覧検索と受講生復元処理も含めてテストは成功しました。
